### PR TITLE
Hide Viewers on Desktop and Hide Server URL Field with Filled Default Value

### DIFF
--- a/example/src/PreJoinPage.tsx
+++ b/example/src/PreJoinPage.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 
 export const PreJoinPage = () => {
   // state to pass onto room
-  const [url, setUrl] = useState('ws://localhost:7880');
+  const [url, setUrl] = useState('wss://livekitpoc.lumina.mba');
   const [token, setToken] = useState<string>('');
   const [simulcast, setSimulcast] = useState(true);
   const [dynacast, setDynacast] = useState(true);
@@ -123,20 +123,20 @@ export const PreJoinPage = () => {
 
   return (
     <div className="prejoin">
-      <main>
-        <h2>Yuk Manggung Live Lumina!</h2>
-        <hr />
-        <div className="entrySection">
-          <div>
+      <main style={{"display": "flex", "flexDirection": "column", "justifyContent": "center", "alignItems": "center"}}>
+        <h2>Panggung Live Lumina</h2>
+
+        <div className="entrySection" style={{"display": "flex", "justifyContent": "center", "alignItems": "center"}}>
+          <div style={{"display": "none"}}>
             <div className="label">Server URL</div>
             <div>
               <input type="text" name="url" value={url} onChange={(e) => setUrl(e.target.value)} />
             </div>
           </div>
-          <div>
-            <div className="label">Token</div>
-            <div>
+          <div style={{"paddingBottom": "20px"}}>
+            <div style={{"width": "400px"}}>
               <input
+                placeholder="Masukkan token kamu disini..."
                 type="text"
                 name="token"
                 value={token}
@@ -144,7 +144,9 @@ export const PreJoinPage = () => {
               />
             </div>
           </div>
-          <div className="options">
+        </div>
+
+        <div className="options" style={{"display": "flex", "justifyContent": "center", "alignItems": "center"}}>
             <div>
               <input
                 id="simulcast-option"
@@ -176,13 +178,12 @@ export const PreJoinPage = () => {
               <label htmlFor="adaptivestream-option">Adaptive Stream</label>
             </div>
           </div>
-        </div>
 
         <div className="videoSection">
           <AspectRatio ratio={16 / 9}>{videoElement}</AspectRatio>
         </div>
 
-        <div className="controlSection">
+        <div className="controlSection" style={{"display": "flex", "justifyContent": "center", "alignItems": "center"}}>
           <div>
             <AudioSelectButton
               isMuted={!audioEnabled}
@@ -194,8 +195,6 @@ export const PreJoinPage = () => {
               onClick={toggleVideo}
               onSourceSelected={selectVideoDevice}
             />
-          </div>
-          <div className="right">
             <ControlButton
               label="Connect"
               disabled={connectDisabled}

--- a/packages/components/src/components/ControlsView.tsx
+++ b/packages/components/src/components/ControlsView.tsx
@@ -85,6 +85,10 @@ export const ControlsView = ({
     );
   }
 
+  const screenShareCaptureOptions = {
+    audio: true,
+  };
+
   const [screenButtonDisabled, setScreenButtonDisabled] = React.useState(false);
   let screenButton: ReactElement | undefined;
   if (enableScreenShare) {
@@ -97,7 +101,7 @@ export const ControlsView = ({
         onClick={() => {
           setScreenButtonDisabled(true);
           room.localParticipant
-            .setScreenShareEnabled(!enabled)
+            .setScreenShareEnabled(!enabled, screenShareCaptureOptions)
             .finally(() => setScreenButtonDisabled(false));
         }}
       />

--- a/packages/components/src/components/desktop/GridStage.tsx
+++ b/packages/components/src/components/desktop/GridStage.tsx
@@ -19,30 +19,38 @@ export const GridStage = ({
   // compute visible participants and sort.
   useEffect(() => {
     // determine grid size
-    let numVisible = 1;
-    if (participants.length === 1) {
+    let numVisible = 0;
+    participants.forEach((p) => {
+      if (p.permissions?.canPublish) {
+        numVisible += 1;
+      }
+    });
+    if (numVisible === 1) {
       setGridClass(styles.grid1x1);
-    } else if (participants.length === 2) {
+    } else if (numVisible === 2) {
       setGridClass(styles.grid2x1);
       numVisible = 2;
-    } else if (participants.length <= 4) {
+    } else if (numVisible <= 4) {
       setGridClass(styles.grid2x2);
-      numVisible = Math.min(participants.length, 4);
-    } else if (participants.length <= 9) {
+      numVisible = Math.min(numVisible, 4);
+    } else if (numVisible <= 9) {
       setGridClass(styles.grid3x3);
-      numVisible = Math.min(participants.length, 9);
-    } else if (participants.length <= 16) {
+      numVisible = Math.min(numVisible, 9);
+    } else if (numVisible <= 16) {
       setGridClass(styles.grid4x4);
-      numVisible = Math.min(participants.length, 16);
+      numVisible = Math.min(numVisible, 16);
     } else {
       setGridClass(styles.grid5x5);
-      numVisible = Math.min(participants.length, 25);
+      numVisible = Math.min(numVisible, 25);
     }
 
     // remove any participants that are no longer connected
     const newParticipants: Participant[] = [];
-    visibleParticipants.forEach((p) => {
-      if (room?.participants.has(p.sid) || room?.localParticipant.sid === p.sid) {
+    participants.forEach((p) => {
+      if (
+        (room?.participants.has(p.sid) || room?.localParticipant.sid === p.sid) &&
+        p.permissions?.canPublish
+      ) {
         newParticipants.push(p);
       }
     });


### PR DESCRIPTION
# What's Changed?

#### 1. We hide server URL and auto-fill it with default value `wss://livekitpoc.lumina.mba`

Before:
<img width="888" alt="CleanShot 2022-09-05 at 19 35 22@2x" src="https://user-images.githubusercontent.com/72017138/188450577-0e791663-a4f0-4d90-8799-f7a53338d8e4.png">

After:
<img width="888" alt="CleanShot 2022-09-05 at 19 36 13@2x" src="https://user-images.githubusercontent.com/72017138/188450722-a5c61ea5-1d07-4ece-8cea-4dd22709a459.png">

#### 2. We enable share sound from system

![CleanShot 2022-09-05 at 19 37 36@2x](https://user-images.githubusercontent.com/72017138/188451101-41d30796-df40-4a15-af10-e586a3fe1985.png)

#### 3. Hide viewers from streamers platform

> We don't want to show our viewers as blank placeholder ParticipantView on our manggung. So we only show participant with permissions `publish`